### PR TITLE
CI: add settings.gradle.kts and Gradle 8.7 workflow for AGP 8.5.x

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build Debug APK
         uses: gradle/gradle-build-action@v3
         with:
-          gradle-version: '8.9'
+          gradle-version: '8.7'
           arguments: assembleDebug
 
       - name: Upload APK

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,4 @@
 plugins {
-    id("com.android.application") version "8.4.2" apply false
-    kotlin("android") version "1.9.24" apply false
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+    id("com.android.application") version "8.5.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,18 +1,4 @@
-pluginManagement {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-rootProject.name = "daemon-portal"
+pluginManagement { repositories { google(); mavenCentral(); gradlePluginPortal() } }
+dependencyResolutionManagement { repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS); repositories { google(); mavenCentral() } }
+rootProject.name = "DaemonPortal"
 include(":app")


### PR DESCRIPTION
## Summary
- configure plugin and dependency repositories in settings.gradle.kts
- update to Android Gradle Plugin 8.5.0 and Kotlin 1.9.24
- run CI with Gradle 8.7 and upload debug APK artifact

## Testing
- `gradle assembleDebug` *(fails: Plugin [id: 'com.android.application', version: '8.5.0', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ed73e0f9c8326b45c01dcffbfb461