### PR TITLE
fix: robust GitHub App token bootstrap

### DIFF
--- a/ghcred/README.md
+++ b/ghcred/README.md
@@ -1,0 +1,19 @@
+# GitHub Credential Helper
+
+`startup.sh` creates a GitHub App JSON Web Token (JWT) and mints a short-lived installation access token. Both values are exported so subsequent commands can interact with the GitHub API.
+
+## Usage
+
+```bash
+cd ghcred
+./startup.sh
+```
+
+The script relies on the following environment variables (all have defaults):
+
+- `APP_ID` – GitHub App ID (default `1786337`)
+- `PEM_PATH` – path to the RSA private key (default `private-key.pem` in this directory)
+- `INSTALLATION_ID_FILE` – cache for the installation ID (`installation_id.txt`)
+- `DEBUG` – set to `1` for verbose output
+
+On success it exports `JWT` and `TOKEN` for use in subsequent API calls.

--- a/ghcred/startup.sh
+++ b/ghcred/startup.sh
@@ -1,61 +1,88 @@
-#!/data/data/com.termux/files/usr/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # === CONFIGURATION ===
-APP_ID=1786337
-PEM_PATH="./private-key.pem"
-INSTALLATION_ID_FILE="./installation_id.txt"
+# These can be overridden via environment variables before calling the script
+APP_ID="${APP_ID:-1786337}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PEM_PATH="${PEM_PATH:-$SCRIPT_DIR/private-key.pem}"
+INSTALLATION_ID_FILE="${INSTALLATION_ID_FILE:-$SCRIPT_DIR/installation_id.txt}"
+
+# Optional DEBUG flag: DEBUG=1 bash startup.sh
+if [[ "${DEBUG:-0}" == 1 ]]; then
+  set -x
+fi
 
 # === Create a short-lived JWT for GitHub App ===
 create_jwt() {
-  local now=$(date +%s)
-  local exp=$((now + 540))
-  local header='{"alg":"RS256","typ":"JWT"}'
-  local payload="{\"iat\":$now,\"exp\":$exp,\"iss\":$APP_ID}"
-
-  local b64_header=$(echo -n "$header" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
-  local b64_payload=$(echo -n "$payload" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
-  local data="$b64_header.$b64_payload"
-
-  local signature=$(echo -n "$data" | openssl dgst -sha256 -sign "$PEM_PATH" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
-  echo "$data.$signature"
+  local now exp header payload b64_header b64_payload unsigned signature
+  now=$(date +%s)
+  exp=$((now + 600))
+  header='{"alg":"RS256","typ":"JWT"}'
+  payload=$(printf '{"iat":%s,"exp":%s,"iss":%s}' "$now" "$exp" "$APP_ID")
+  b64_header=$(printf '%s' "$header" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+  b64_payload=$(printf '%s' "$payload" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+  unsigned="$b64_header.$b64_payload"
+  signature=$(printf '%s' "$unsigned" | openssl dgst -sha256 -sign "$PEM_PATH" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+  printf '%s.%s' "$unsigned" "$signature"
 }
 
 # === Get installation ID (only needed once per app install) ===
 get_installation_id() {
-  jwt=$1
-  curl -s -H "Authorization: Bearer $jwt" \
+  local jwt="$1"
+  curl -s \
+       -H "Authorization: Bearer $jwt" \
        -H "Accept: application/vnd.github+json" \
+       -H "User-Agent: ghcred" \
        https://api.github.com/app/installations \
-       | jq '.[0].id' > "$INSTALLATION_ID_FILE"
+       | jq -r '.[0].id' > "$INSTALLATION_ID_FILE"
 }
 
 # === Mint access token ===
 mint_token() {
-  jwt=$1
+  local jwt="$1"
+  local installation_id
   installation_id=$(cat "$INSTALLATION_ID_FILE")
   curl -s -X POST \
     -H "Authorization: Bearer $jwt" \
     -H "Accept: application/vnd.github+json" \
+    -H "User-Agent: ghcred" \
     https://api.github.com/app/installations/$installation_id/access_tokens \
     | jq -r .token
 }
 
 # === MAIN ===
+if ! openssl rsa -check -in "$PEM_PATH" >/dev/null 2>&1; then
+  echo "[!] Invalid or unreadable private key at $PEM_PATH" >&2
+  exit 1
+fi
+
 echo "[+] Creating JWT..."
 jwt=$(create_jwt)
+if [[ -z "$jwt" ]]; then
+  echo "[!] Failed to create JWT" >&2
+  exit 1
+fi
+if [[ "${DEBUG:-0}" == 1 ]]; then
+  echo "JWT=$jwt"
+fi
+echo "[✓] JWT created"
 
-if [ ! -f "$INSTALLATION_ID_FILE" ]; then
+if [[ ! -s "$INSTALLATION_ID_FILE" ]]; then
   echo "[+] Getting installation ID from GitHub..."
-  get_installation_id "$jwt"
+  get_installation_id "$jwt" || {
+    echo "[!] Failed to fetch installation ID" >&2
+    exit 1
+  }
 fi
 
 echo "[+] Minting short-lived GitHub token..."
 TOKEN=$(mint_token "$jwt")
-
-if [[ -z "$TOKEN" ]]; then
-  echo "[!] ERROR: Failed to mint token"
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+  echo "[!] ERROR: Failed to mint token" >&2
   exit 1
 fi
 
 export TOKEN
+export JWT="$jwt"
 echo "[✓] TOKEN exported to \$TOKEN"


### PR DESCRIPTION
## Summary
- make GitHub token bootstrap script resilient to missing key paths and invalid keys
- add debug mode, user agent header and environment variable overrides
- document how to use the credential helper

## Testing
- `./startup.sh` *(failed: Failed to fetch installation ID)*
- `apt-get update` *(failed: repository 403 - unable to install shellcheck)*


------
https://chatgpt.com/codex/tasks/task_e_689f930ba3348326ab0a6af9fa8c0249