### PR TITLE
build: enable AndroidX to fix CI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
## Summary
- Enable AndroidX via gradle.properties
- Jetifier: omitted because no support library references were found
- No binary changes; CI should pass and produce APK artifact.

## Testing
- `gradle help`


------
https://chatgpt.com/codex/tasks/task_e_68a21b95be7083269a79a10972419534