### PR TITLE
ci: always ensure gradle wrapper; fallback to CLI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,18 +19,33 @@ jobs:
           java-version: '17'
       - uses: android-actions/setup-android@v3
       - run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+      # Install a Gradle CLI so we can (re)generate the wrapper reliably
       - name: Ensure Gradle CLI
         run: |
           curl -sL https://services.gradle.org/distributions/gradle-8.7-bin.zip -o gradle.zip
           unzip -q gradle.zip
           echo "$PWD/gradle-8.7/bin" >> $GITHUB_PATH
-      - name: Generate wrapper if missing
+          gradle --version
+
+      # ✅ Always ensure wrapper scripts + jar exist; then make script executable
+      - name: Ensure Gradle Wrapper
         run: |
-          if [ ! -f gradle/wrapper/gradle-wrapper.jar ]; then
+          if [ ! -f gradlew ] || [ ! -f gradle/wrapper/gradle-wrapper.jar ]; then
             gradle wrapper --gradle-version 8.7
           fi
+          chmod +x gradlew
+          ls -la gradlew gradle/wrapper || true
+
+      # Build; prefer wrapper, but fall back to CLI if something is off
       - name: Build debug
-        run: ./gradlew --no-daemon assembleDebug
+        run: |
+          set -e
+          if [ -x ./gradlew ]; then
+            ./gradlew --no-daemon assembleDebug
+          else
+            echo "Wrapper missing; falling back to Gradle CLI"
+            gradle --no-daemon assembleDebug
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: daemon-portal-debug-apk


### PR DESCRIPTION
## Summary
- ensure Gradle CLI and wrapper are always present
- fall back to Gradle CLI if wrapper is missing

## Testing
- `yamllint .github/workflows/android.yml` *(fails: missing document start, truthy, brackets, line-length)*
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/android.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a2202531e883269c0c6a202d647480