### PR TITLE
app: Start URL override + login fallback + popup support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,10 +11,10 @@ android {
         applicationId = "com.daemon.portal"
         minSdk = 26
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.0.1"
 
-        buildConfigField("String","HOME_URL","\"https://chatgpt.com/g/XXXXXXXX-the-daemon\"")
+        buildConfigField("String","HOME_URL","\"https://chatgpt.com/\"")
         buildConfigField("boolean","FORCE_DESKTOP_MODE","true")
         buildConfigField("boolean","ALLOW_THIRD_PARTY_COOKIES","true")
     }

--- a/app/src/main/java/com/daemon/portal/MainActivity.kt
+++ b/app/src/main/java/com/daemon/portal/MainActivity.kt
@@ -3,18 +3,32 @@ package com.daemon.portal
 import android.Manifest
 import android.net.Uri
 import android.os.Bundle
+import android.os.Message
+import android.view.Menu
+import android.view.MenuItem
 import android.webkit.CookieManager
 import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.EditText
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     private lateinit var webView: WebView
     private var filePathCallback: ValueCallback<Array<Uri>>? = null
+
+    private val prefs by lazy { getSharedPreferences("portal", MODE_PRIVATE) }
+
+    private fun getStartUrl(): String = prefs.getString("start_url", BuildConfig.HOME_URL)!!
+    private fun setStartUrl(u: String) { prefs.edit().putString("start_url", u).apply() }
+    private fun getTargetAfterLogin(): String? = prefs.getString("target_after_login", null)
+    private fun setTargetAfterLogin(u: String?) { prefs.edit().putString("target_after_login", u).apply() }
 
     private val fileChooser =
         registerForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
@@ -39,9 +53,11 @@ class MainActivity : AppCompatActivity() {
         val settings = webView.settings
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
-        settings.allowFileAccess = true
-        settings.useWideViewPort = true
         settings.loadWithOverviewMode = true
+        settings.useWideViewPort = true
+        settings.javaScriptCanOpenWindowsAutomatically = true
+        settings.setSupportMultipleWindows(true)
+        settings.allowFileAccess = true
 
         if (BuildConfig.FORCE_DESKTOP_MODE) {
             settings.userAgentString =
@@ -60,16 +76,91 @@ class MainActivity : AppCompatActivity() {
             override fun onShowFileChooser(
                 view: WebView?,
                 filePathCallback: ValueCallback<Array<Uri>>?,
-                fileChooserParams: FileChooserParams?
+                fileChooserParams: FileChooserParams?,
             ): Boolean {
                 this@MainActivity.filePathCallback = filePathCallback
                 fileChooser.launch(arrayOf("*/*"))
                 return true
             }
+
+            override fun onCreateWindow(
+                view: WebView?,
+                isDialog: Boolean,
+                isUserGesture: Boolean,
+                resultMsg: Message?,
+            ): Boolean {
+                val href = view?.hitTestResult?.extra
+                if (href != null) {
+                    view.loadUrl(href)
+                }
+                return false
+            }
         }
 
-        webView.webViewClient = WebViewClient()
-        webView.loadUrl(BuildConfig.HOME_URL)
+        webView.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(
+                view: WebView,
+                request: WebResourceRequest,
+            ): Boolean {
+                view.loadUrl(request.url.toString())
+                return true
+            }
+
+            override fun onReceivedHttpError(
+                view: WebView,
+                request: WebResourceRequest,
+                errorResponse: WebResourceResponse,
+            ) {
+                val url = request.url
+                if (
+                    request.isForMainFrame &&
+                    url.host?.endsWith("chatgpt.com") == true &&
+                    url.path?.startsWith("/g/") == true &&
+                    errorResponse.statusCode in setOf(401, 403, 404)
+                ) {
+                    setTargetAfterLogin(url.toString())
+                    view.loadUrl(BuildConfig.HOME_URL)
+                }
+            }
+
+            override fun onPageFinished(view: WebView, url: String) {
+                val uri = Uri.parse(url)
+                val target = getTargetAfterLogin()
+                if (uri.host == "chatgpt.com" && target != null && !url.contains("/g/")) {
+                    setTargetAfterLogin(null)
+                    view.postDelayed({ view.loadUrl(target) }, 300)
+                }
+            }
+        }
+
+        webView.loadUrl(getStartUrl())
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.main, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return if (item.itemId == R.id.action_set_url) {
+            val input = EditText(this)
+            input.setText(getStartUrl())
+            AlertDialog.Builder(this)
+                .setTitle("Set Portal URL")
+                .setView(input)
+                .setPositiveButton("OK") { _, _ ->
+                    val newUrl = input.text.toString()
+                    if (newUrl.startsWith("https://")) {
+                        setStartUrl(newUrl)
+                        webView.loadUrl(newUrl)
+                    }
+                }
+                .setNegativeButton("Cancel", null)
+                .show()
+            true
+        } else {
+            super.onOptionsItemSelected(item)
+        }
     }
 
     override fun onBackPressed() {

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -1,0 +1,7 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_set_url"
+        android:title="Set Portal URL…"
+        app:showAsAction="never" />
+</menu>


### PR DESCRIPTION
## Summary
- allow overriding start URL via SharedPreferences and menu prompt
- handle login fallback for GPT deep links and retry after authentication
- enable popup windows and multiple windows support

## Testing
- `gradle build` *(fails: Could not determine dependencies, SDK packages not installed/accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68a227c98aac83269b762477eb542dce