### PR TITLE
app: session-friendly polish (status + auto-retry + actions)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.daemon.portal"
         minSdk = 26
         targetSdk = 34
-        versionCode = 2
-        versionName = "1.0.1"
+        versionCode = 3
+        versionName = "1.0.2"
 
         buildConfigField("String","HOME_URL","\"https://chatgpt.com/\"")
         buildConfigField("boolean","FORCE_DESKTOP_MODE","true")


### PR DESCRIPTION
## Summary
- webview detects login via /api/auth/session and auto-returns to saved GPT target after sign-in
- tiny top bar shows sign-in state and provides Reload, Home, Chrome, and Clear cookies actions
- enable persistent cookies and bump app version

## Testing
- `gradle assembleDebug --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23383a2848326b033d2ba88e5514c