### PR TITLE
Redirect to custom GPT after login

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ Daemon Portal is a single-activity WebView app written in Kotlin. It loads a con
 Set the `HOME_URL` value in [`app/build.gradle.kts`](app/build.gradle.kts). By default it points to:
 
 ```
-https://chatgpt.com/g/g-XXXXXXXXXXXXXXX-the-daemon
+https://chatgpt.com/
+```
+
+The `LOGIN_REDIRECT_URL` defines where the app navigates after a successful sign in. By default it opens:
+
+```
+https://chatgpt.com/g/g-68320ed4e74081919f11e7d6a993ee44-the-daemon
 ```
 
 ## Build

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,7 @@ android {
         versionName = "1.0.2"
 
         buildConfigField("String","HOME_URL","\"https://chatgpt.com/\"")
+        buildConfigField("String","LOGIN_REDIRECT_URL","\"https://chatgpt.com/g/g-68320ed4e74081919f11e7d6a993ee44-the-daemon\"")
         buildConfigField("boolean","FORCE_DESKTOP_MODE","true")
         buildConfigField("boolean","ALLOW_THIRD_PARTY_COOKIES","true")
     }

--- a/app/src/main/java/com/daemon/portal/MainActivity.kt
+++ b/app/src/main/java/com/daemon/portal/MainActivity.kt
@@ -35,26 +35,16 @@ class MainActivity : AppCompatActivity() {
 
     private fun getStartUrl(): String = prefs.getString("start_url", BuildConfig.HOME_URL)!!
     private fun setStartUrl(u: String) { prefs.edit().putString("start_url", u).apply() }
-    private fun getTargetAfterLogin(): String? = prefs.getString("target_after_login", null)
-    private fun setTargetAfterLogin(u: String?) { prefs.edit().putString("target_after_login", u).apply() }
     private fun onLoggedIn() {
         isLoggedIn = true
         statusView.text = "Signed in"
-        val target = getTargetAfterLogin()
-        if (target != null) {
-            setTargetAfterLogin(null)
-            webView.post { webView.loadUrl(target) }
-        }
+        webView.post { webView.loadUrl(BuildConfig.LOGIN_REDIRECT_URL) }
     }
 
     private fun onLoggedOut() {
         isLoggedIn = false
         statusView.text = "Not signed in"
-        val current = webView.url
-        if (current != null && Uri.parse(current).path?.startsWith("/g/") == true) {
-            setTargetAfterLogin(current)
-            webView.loadUrl(BuildConfig.HOME_URL)
-        }
+        webView.loadUrl(BuildConfig.HOME_URL)
     }
 
     inner class JsBridge {


### PR DESCRIPTION
## Summary
- redirect to custom GPT after login via new `LOGIN_REDIRECT_URL`
- load home page when logged out and document new redirect behavior

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a237d3d65c8326912159449a3ddfb2