### PR TITLE
app: auth landing + session preflight; keep GPT in-webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Minimal Android WebView wrapper that opens the [Daemon GPT](https://chatgpt.com/g/g-68320ed4e74081919f11e7d6a993ee44-the-daemon) by default.
 It runs in desktop mode, supports file uploads, camera and microphone access, back navigation, and login fallback.
 
+First launch: if you’re not signed in, you’ll see a clean landing screen. Tap “Sign in”, complete login, and you’ll be auto-routed to The Daemon. After that, sessions persist.
+
 ## Start URL
 
 The default start URL is:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.daemon.portal"
         minSdk = 26
         targetSdk = 34
-        versionCode = 4
-        versionName = "1.0.3"
+        versionCode = 5
+        versionName = "1.0.4"
 
         buildConfigField("String", "HOME_URL", "\"https://chatgpt.com/g/g-68320ed4e74081919f11e7d6a993ee44-the-daemon\"")
         buildConfigField("boolean", "FORCE_DESKTOP_MODE", "true")

--- a/app/src/main/assets/landing.html
+++ b/app/src/main/assets/landing.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The Daemon – Sign in</title>
+<style>
+ html,body{margin:0;height:100%;background:#0b0b0b;color:#e5e5e5;font:16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial}
+ .wrap{min-height:100%;display:flex;align-items:center;justify-content:center;padding:24px}
+ .card{max-width:560px;width:100%;background:#111;border:1px solid #222;border-radius:16px;padding:24px;box-shadow:0 6px 30px rgba(0,0,0,.35)}
+ h1{font-weight:700;margin:0 0 8px}
+ p{opacity:.8;margin:0 0 16px}
+ button{background:#2f2f2f;border:1px solid #3a3a3a;border-radius:10px;color:#fff;padding:12px 16px;font-weight:600;cursor:pointer}
+ button:active{transform:translateY(1px)}
+ .hint{opacity:.7;font-size:12px;margin-top:10px}
+</style>
+<body>
+ <div class="wrap"><div class="card">
+  <h1>Welcome to The Daemon</h1>
+  <p>Sign in to ChatGPT to continue. You’ll return to your Daemon automatically after login.</p>
+  <button onclick="location.href='https://chatgpt.com/'">Sign in to ChatGPT</button>
+  <div class="hint">No credentials are stored here. This page just opens ChatGPT login inside the app.</div>
+ </div></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show a minimal landing screen when logged out and prompt ChatGPT sign-in
- add session preflight logic to reload desired page after login and keep target=_blank inside WebView
- remove the debug overlay and bump app version

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68a24166359c8326b728f9e8c1f1cdc9